### PR TITLE
Update default host

### DIFF
--- a/src/opentelemetry/ext/lightstep/__init__.py
+++ b/src/opentelemetry/ext/lightstep/__init__.py
@@ -21,7 +21,7 @@ class LightStepSpanExporter(SpanExporter):
         self,
         name,
         token,
-        host="collector.lightstep.com",
+        host="ingest.lightstep.com",
         port=443,
         encryption="tls",
         verbosity=0,


### PR DESCRIPTION
`collector.lightstep.com` is deprecated.